### PR TITLE
fix: preserve milestone status when no longer present in MSX results

### DIFF
--- a/app/services/milestone_sync.py
+++ b/app/services/milestone_sync.py
@@ -705,17 +705,18 @@ def _apply_customer_milestones(
                 existing_milestones_map[msx_id] = milestone
                 result["created"] += 1
 
-        # Deactivate milestones for this customer that are no longer in MSX
+        # Handle milestones for this customer that are no longer in the MSX
+        # query results.  The sync query uses open_opportunities_only=True
+        # and current_fy_only=True, so a milestone can disappear from results
+        # for reasons other than completion (opportunity closed, FY filter,
+        # account re-parent, etc.).  We must NOT assume "Completed" - just
+        # mark them as synced so we know we checked.
         for msx_id, existing in existing_milestones_map.items():
             if existing.customer_id != customer.id:
                 continue
             if existing.msx_status not in ACTIVE_STATUSES:
                 continue
             if msx_id not in seen_msx_ids:
-                if existing.notes:
-                    existing.last_synced_at = now
-                    continue
-                existing.msx_status = "Completed"
                 existing.last_synced_at = now
                 result["deactivated"] += 1
 

--- a/templates/partials/milestone_tracker_content.html
+++ b/templates/partials/milestone_tracker_content.html
@@ -183,7 +183,7 @@
         <tbody>
             {% for ms in milestones %}
             <tr class="milestone-row" style="cursor: pointer;"
-                onclick="openMilestoneDetail(event, {{ ms.id }}, '{{ ms.title|replace("'", "\\'") }}', '{{ ms.msx_status or '' }}', '{{ ms.url or '' }}');"
+                onclick="openMilestoneDetail(event, {{ ms.id }}, '{{ ms.title|replace("'", "\\'") }}', '{{ ms.status or '' }}', '{{ ms.url or '' }}');"
                 data-seller-id="{{ ms.seller.id if ms.seller else '' }}"
                 data-status="{{ ms.status }}"
                 data-area="{{ ms.workload_area }}"

--- a/templates/partials/milestone_view_content.html
+++ b/templates/partials/milestone_view_content.html
@@ -17,9 +17,6 @@
         <h1 class="mb-0 text-truncate" style="min-width: 0;" title="{{ milestone.title or 'Untitled Milestone' }}">
             {{ milestone.title or 'Untitled Milestone' }}
         </h1>
-        {% if milestone.msx_status %}
-        <span class="badge fs-6 {% if milestone.msx_status == 'On Track' %}bg-success{% elif milestone.msx_status == 'At Risk' %}bg-warning text-dark{% elif milestone.msx_status == 'Blocked' %}bg-danger{% elif milestone.msx_status == 'Completed' %}bg-info{% else %}bg-secondary{% endif %}" id="statusBadgeTop">{{ milestone.msx_status }}</span>
-        {% endif %}
     </div>
     <div class="flex-shrink-0 d-flex gap-2">
         <a href="{{ milestone.url }}" target="_blank" class="btn btn-outline-success text-nowrap">
@@ -82,6 +79,19 @@
                 <!-- Cached details shown immediately -->
                 <div id="detailsCached">
                     <ul class="list-group list-group-flush">
+                        {% if milestone.msx_status %}
+                        <li class="list-group-item d-flex justify-content-between" id="statusRow">
+                            <span class="text-muted">Status</span>
+                            <span id="statusValue">
+                                <span class="badge {% if milestone.msx_status == 'On Track' %}bg-success{% elif milestone.msx_status == 'At Risk' %}bg-warning text-dark{% elif milestone.msx_status == 'Blocked' %}bg-danger{% elif milestone.msx_status == 'Completed' %}bg-info{% else %}bg-secondary{% endif %}">{{ milestone.msx_status }}</span>
+                            </span>
+                        </li>
+                        {% else %}
+                        <li class="list-group-item d-flex justify-content-between" id="statusRow" style="display:none !important;">
+                            <span class="text-muted">Status</span>
+                            <span id="statusValue"></span>
+                        </li>
+                        {% endif %}
                         {% if milestone.owner_name %}
                         <li class="list-group-item d-flex justify-content-between" id="ownerRow">
                             <span class="text-muted">Owner</span>
@@ -386,14 +396,17 @@ function renderDetails(ms) {
     const spinner = document.getElementById('detailsSpinner');
     if (spinner) spinner.style.display = 'none';
 
-    // Update the status badge at top of page
-    const badge = document.getElementById('statusBadgeTop');
-    if (badge && ms.msx_status) {
-        badge.textContent = ms.msx_status;
-        badge.className = 'badge fs-6 ' + ({
+    // Update the status row in details card
+    const statusRow = document.getElementById('statusRow');
+    const statusVal = document.getElementById('statusValue');
+    if (statusRow && statusVal && ms.msx_status) {
+        const cls = {
             'On Track': 'bg-success', 'At Risk': 'bg-warning text-dark',
             'Blocked': 'bg-danger', 'Completed': 'bg-info'
-        }[ms.msx_status] || 'bg-secondary');
+        }[ms.msx_status] || 'bg-secondary';
+        statusVal.innerHTML = '<span class="badge ' + cls + '">' + escapeHtml(ms.msx_status) + '</span>';
+        statusRow.style.display = '';
+        statusRow.classList.add('d-flex');
     }
     // Update owner (preserve existing link if present)
     const ownerRow = document.getElementById('ownerRow');

--- a/tests/test_milestone_tracker.py
+++ b/tests/test_milestone_tracker.py
@@ -372,7 +372,7 @@ class TestMilestoneSyncService:
     
     @patch('app.services.milestone_sync.get_milestones_by_account')
     def test_sync_deactivates_missing_milestones(self, mock_get, app, sample_data):
-        """Milestones no longer in MSX should be marked as completed."""
+        """Milestones no longer in MSX results should keep their status, not be force-completed."""
         customer_id = self._create_test_customer_with_tpid_url(app, sample_data)
         
         with app.app_context():
@@ -391,7 +391,7 @@ class TestMilestoneSyncService:
             db.session.commit()
             disappearing_id = disappearing.id
         
-        # MSX returns empty list — our milestone is gone
+        # MSX returns empty list — our milestone is gone from the query
         mock_get.return_value = {
             "success": True,
             "milestones": [],
@@ -411,7 +411,9 @@ class TestMilestoneSyncService:
             assert result["deactivated"] == 1
             
             ms = db.session.get(Milestone, disappearing_id)
-            assert ms.msx_status == "Completed"
+            # Status should be preserved, not force-set to "Completed"
+            assert ms.msx_status == "On Track"
+            assert ms.last_synced_at is not None
             
             # Cleanup
             db.session.delete(ms)


### PR DESCRIPTION
Fix milestone status disparity between tracker list and detail views

The milestone sync was incorrectly force-marking milestones as "Completed" when they disappeared from filtered MSX API results, causing status mismatches between the tracker row, the detail modal, and MSX itself. This also inflated the U2C Attainment report's committed section with false positives.

Changes:

milestone_sync.py - Removed the msx_status = "Completed" assignment in the deactivation loop. Milestones no longer returned by the MSX query (which uses open_opportunities_only and current_fy_only filters) now preserve their existing status instead of being falsely marked Completed. The last_synced_at timestamp is still updated so we know the sync checked them.

milestone_tracker_content.html - Fixed the modal onclick to pass ms.status (the dict key) instead of ms.msx_status (which doesn't exist on the tracker dict), so the modal badge shows the correct status immediately on open.

milestone_view_content.html - Moved the status badge from the page header into the Details card as a proper row (consistent with Owner, Commitment, etc.). The cached status renders immediately, and the live MSX fetch updates it in-place when it completes.

test_milestone_tracker.py - Updated test_sync_deactivates_missing_milestones to assert that disappeared milestones retain their original status ("On Track") rather than being force-set to "Completed".