### PR TITLE
Implement Azure CLI isolation and environment-specific configuration for improved management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ data/
 # OS
 .DS_Store
 Thumbs.db
+/Microsoft/
 
 # Sentinel reports
 .sentinel/

--- a/app/routes/metrics.py
+++ b/app/routes/metrics.py
@@ -16,6 +16,7 @@ Cards (in order):
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -468,7 +469,7 @@ def api_metrics_sign_in():
         if sys.platform == 'win32':
             CREATE_NEW_CONSOLE = 0x00000010
             creationflags = CREATE_NEW_CONSOLE
-        subprocess.Popen(cmd, creationflags=creationflags, close_fds=True)
+        subprocess.Popen(cmd, creationflags=creationflags, close_fds=True, env=os.environ.copy())
     except Exception as exc:  # noqa: BLE001
         logger.exception('Failed to spawn az login')
         return jsonify({'error': f'Failed to spawn az login: {exc}'}), 500

--- a/app/services/msx_auth.py
+++ b/app/services/msx_auth.py
@@ -23,6 +23,7 @@ import time
 import logging
 import re
 import sys
+import os
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 
@@ -630,6 +631,7 @@ def start_az_login(scope: str | None = None) -> Dict[str, Any]:
                 cmd,
                 shell=True,
                 creationflags=_sp.CREATE_NEW_CONSOLE,
+                env=os.environ.copy(),  # Explicit inheritance for isolated Azure CLI config
             )
         else:
             # On Linux/Mac, launch in background
@@ -637,6 +639,7 @@ def start_az_login(scope: str | None = None) -> Dict[str, Any]:
                 args,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                env=os.environ.copy(),  # Explicit inheritance for isolated Azure CLI config
             )
 
         _az_login_state = {
@@ -775,7 +778,8 @@ def start_device_code_flow() -> Dict[str, Any]:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
-            shell=IS_WINDOWS  # Required on Windows to find az in PATH
+            shell=IS_WINDOWS,  # Required on Windows to find az in PATH
+            env=os.environ.copy(),  # Explicit inheritance for isolated Azure CLI config
         )
         _device_code_state["process"] = process
         

--- a/scripts/server.ps1
+++ b/scripts/server.ps1
@@ -19,6 +19,78 @@ param(
 $RepoRoot = Split-Path $PSScriptRoot -Parent
 Set-Location $RepoRoot
 
+# Always pin Azure CLI state to an environment-specific path under USERPROFILE.
+# Production uses %USERPROFILE%\SalesBuddy\.azure, development uses
+# %USERPROFILE%\SalesBuddyDev\.azure, and all other values default to production.
+function Initialize-IsolatedAzCliContext {
+    $baseUserProfile = $env:USERPROFILE
+    if (-not $baseUserProfile) {
+        $baseUserProfile = [Environment]::GetFolderPath('UserProfile')
+    }
+    if (-not $baseUserProfile) {
+        throw "Unable to resolve user profile path for Sales Buddy runtime context."
+    }
+
+    $flaskEnv = 'production'
+    $envFile = Join-Path $RepoRoot '.env'
+    if (Test-Path $envFile) {
+        foreach ($line in Get-Content $envFile) {
+            if ($line -match '^\s*FLASK_ENV\s*=\s*(.+?)\s*$') {
+                $flaskEnv = $Matches[1].Trim().Trim('"').Trim("'")
+                break
+            }
+        }
+    }
+
+    switch -Regex ($flaskEnv) {
+        '^(?i)production$' { $profileFolder = 'SalesBuddy'; break }
+        '^(?i)development$' { $profileFolder = 'SalesBuddyDev'; break }
+        default { $profileFolder = 'SalesBuddy' }
+    }
+    $salesBuddyHome = Join-Path $baseUserProfile $profileFolder
+    $azureConfigDir = Join-Path $salesBuddyHome '.azure'
+    $defaultAzureConfigDir = Join-Path $baseUserProfile '.azure'
+
+    if (-not (Test-Path $salesBuddyHome)) {
+        New-Item -Path $salesBuddyHome -ItemType Directory -Force | Out-Null
+    }
+
+    # First run bootstrap: if the env-specific .azure folder does not exist yet,
+    # migrate existing default Azure CLI state automatically when available.
+    # Also retry migration if target exists but is empty (failed copy recovery).
+    $azureDirEmpty = @(Get-ChildItem -Path $azureConfigDir -Force -ErrorAction SilentlyContinue).Count -eq 0
+    if (-not (Test-Path $azureConfigDir) -or $azureDirEmpty) {
+        if (Test-Path $defaultAzureConfigDir) {
+            try {
+                Copy-Item -Path $defaultAzureConfigDir -Destination $salesBuddyHome -Recurse -Force -ErrorAction Stop
+            } catch {
+                Write-Host "  [WARNING] Could not migrate Azure CLI config to ${azureConfigDir}: $($_.Exception.Message)" -ForegroundColor Yellow
+                New-Item -Path $azureConfigDir -ItemType Directory -Force | Out-Null
+            }
+        } else {
+            New-Item -Path $azureConfigDir -ItemType Directory -Force | Out-Null
+            $script:AzCliContextFresh = $true
+        }
+    }
+
+    $env:SALESBUDDY_HOME = $salesBuddyHome
+    $env:AZURE_CONFIG_DIR = $azureConfigDir
+
+    # Expose the resolved environment label for the banner
+    switch -Regex ($flaskEnv) {
+        '^(?i)production$' { $script:ResolvedEnvLabel = 'Production'; break }
+        '^(?i)development$' { $script:ResolvedEnvLabel = 'Development'; break }
+        default { $script:ResolvedEnvLabel = 'Production' }
+    }
+}
+
+try {
+    Initialize-IsolatedAzCliContext
+} catch {
+    # Deferred: error is reported after the banner in Main
+    $script:AzCliContextError = $_
+}
+
 # ==============================================================================
 # Helper Functions
 # ==============================================================================
@@ -224,7 +296,26 @@ function Start-Server {
     $serverArgs = @('--host=0.0.0.0', "--port=$Port", '--call', 'app:create_app')
 
     Write-Host "  Starting server on port $Port..." -ForegroundColor Yellow
-    Start-Process -FilePath $waitress -ArgumentList $serverArgs -WorkingDirectory $RepoRoot -WindowStyle Hidden
+    
+    # Use ProcessStartInfo to explicitly pass environment variables (e.g., AZURE_CONFIG_DIR)
+    # to the waitress subprocess, ensuring Azure CLI commands inherit the correct config path.
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $waitress
+    $psi.Arguments = $serverArgs -join ' '
+    $psi.WorkingDirectory = $RepoRoot
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    
+    # Copy current environment and set AZURE_CONFIG_DIR for the subprocess
+    foreach ($key in [System.Environment]::GetEnvironmentVariables([System.EnvironmentVariableTarget]::Process).Keys) {
+        $psi.EnvironmentVariables[$key] = [System.Environment]::GetEnvironmentVariable($key, [System.EnvironmentVariableTarget]::Process)
+    }
+    $psi.EnvironmentVariables['AZURE_CONFIG_DIR'] = $env:AZURE_CONFIG_DIR
+    $psi.EnvironmentVariables['SALESBUDDY_HOME'] = $env:SALESBUDDY_HOME
+    
+    $process = [System.Diagnostics.Process]::Start($psi)
     Start-Sleep -Seconds 3
     if (Test-ServerRunning -Port $Port) {
         Write-Host "  [OK] Server running at http://localhost:$Port" -ForegroundColor Green
@@ -338,6 +429,24 @@ Write-Host ""
 Write-Host "  Sales Buddy" -ForegroundColor Cyan
 Write-Host "  ==========" -ForegroundColor Cyan
 Write-Host ""
+if ($script:AzCliContextError) {
+    $err = $script:AzCliContextError
+    $pos = $err.InvocationInfo
+    $location = if ($pos -and $pos.ScriptName) {
+        "$($pos.ScriptName):$($pos.ScriptLineNumber)"
+    } else { 'unknown' }
+    Write-Host "  [FAILURE] Config directory setup failed" -ForegroundColor Red
+    Write-Host "            Error: $($err.Exception.Message)" -ForegroundColor Red
+    Write-Host "            Location: $location" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "  Azure CLI isolation is not active. The server will start but az commands" -ForegroundColor Yellow
+    Write-Host "  may use the default Azure CLI config (~\.azure) instead of the isolated one." -ForegroundColor Yellow
+    Write-Host ""
+} elseif ($script:AzCliContextFresh) {
+    Write-Host "  [WARNING] No existing Az CLI context detected, new Az Login required" -ForegroundColor Yellow
+} else {
+    Write-Host "  [OK] Config directory and environment variables set as $script:ResolvedEnvLabel" -ForegroundColor Green
+}
 
 # -StopOnly: Read port from .env, stop the server, and exit immediately.
 # Skips all prereq checks (Python, Git, venv, etc.) for instant execution.

--- a/scripts/server.ps1
+++ b/scripts/server.ps1
@@ -99,8 +99,8 @@ try {
 $HasWinget = $false
 try { if (Get-Command winget -ErrorAction SilentlyContinue) { $HasWinget = $true } } catch {}
 
-# Pause for interactive use (skipped when -Force for non-interactive updates)
-function Pause-WithMessage {
+# Wait for interactive use (skipped when -Force for non-interactive updates)
+function Wait-WithMessage {
     param([string]$Message = "Press any key to close...", [string]$Color = "Gray")
     if ($Force) { return }
     Write-Host "`n$Message" -ForegroundColor $Color
@@ -315,7 +315,7 @@ function Start-Server {
     $psi.EnvironmentVariables['AZURE_CONFIG_DIR'] = $env:AZURE_CONFIG_DIR
     $psi.EnvironmentVariables['SALESBUDDY_HOME'] = $env:SALESBUDDY_HOME
     
-    $process = [System.Diagnostics.Process]::Start($psi)
+    [System.Diagnostics.Process]::Start($psi) | Out-Null
     Start-Sleep -Seconds 3
     if (Test-ServerRunning -Port $Port) {
         Write-Host "  [OK] Server running at http://localhost:$Port" -ForegroundColor Green
@@ -325,7 +325,7 @@ function Start-Server {
 }
 
 # One-time rename from legacy database filename
-function Migrate-DatabaseName {
+function Invoke-DatabaseMigration {
     $oldDb = Join-Path $RepoRoot 'data\notehelper.db'
     $newDb = Join-Path $RepoRoot 'data\salesbuddy.db'
     if ((Test-Path $oldDb) -and -not (Test-Path $newDb)) {
@@ -357,7 +357,7 @@ function Backup-Database {
 }
 
 # Pull latest from git (handles stashing dirty files)
-function Pull-Updates {
+function Sync-Updates {
     $dirty = git status --porcelain
     if ($dirty) {
         Write-Host "  Stashing local changes..." -ForegroundColor Gray
@@ -403,7 +403,7 @@ function Install-Dependencies {
 }
 
 # Run database migrations
-function Run-Migrations {
+function Invoke-Migrations {
     Write-Host "  Running migrations..." -ForegroundColor Yellow
     $pythonExe = Join-Path $RepoRoot 'venv\Scripts\python.exe'
     $migrationOutput = & $pythonExe -c "from app import create_app, db; from app.migrations import run_migrations; app = create_app(); app.app_context().push(); run_migrations(db)" 2>&1
@@ -503,7 +503,7 @@ if ($pyVersion) {
 }
 
 if (-not $pythonOk) {
-    if ($pyVersion -eq $null) {
+    if ($null -eq $pyVersion) {
         Write-Host "  [ERROR] Python not found." -ForegroundColor Red
     } else {
         Write-Host "  [ERROR] Python found, but 3.13+ is required." -ForegroundColor Red
@@ -815,7 +815,7 @@ if ($Force) {
     Backup-Database
 
     if ($isGitRepo) {
-        if (-not (Pull-Updates)) {
+        if (-not (Sync-Updates)) {
             Write-Host "  Restarting server with current code..." -ForegroundColor Yellow
             Start-Server -Port $Port
             Pause-WithMessage "UPDATE FAILED - press any key to close..." "Red"
@@ -861,7 +861,7 @@ if ($hasUpdates) {
     Migrate-DatabaseName
     Backup-Database
 
-    if (-not (Pull-Updates)) {
+    if (-not (Sync-Updates)) {
         Write-Host "  Starting server with current code..." -ForegroundColor Yellow
         Start-Server -Port $Port
         Pause-WithMessage "UPDATE FAILED - press any key to close..." "Red"

--- a/start.bat
+++ b/start.bat
@@ -4,9 +4,22 @@ REM Auto-elevates (admin) only if PORT in .env is below 1024 (e.g. port 80)
 cd /d "%~dp0"
 
 set PORT=5151
+set "FLASK_ENV=production"
 if exist .env (
     for /f "tokens=1,2 delims==" %%a in (.env) do (
         if "%%a"=="PORT" set PORT=%%b
+        if "%%a"=="FLASK_ENV" set FLASK_ENV=%%b
+    )
+)
+
+REM Use default USERPROFILE with environment-specific Azure CLI config directory.
+if /I "%FLASK_ENV%"=="production" (
+    set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddy\.azure"
+) else (
+    if /I "%FLASK_ENV%"=="development" (
+        set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddyDev\.azure"
+    ) else (
+        set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddy\.azure"
     )
 )
 

--- a/stop.bat
+++ b/stop.bat
@@ -4,9 +4,22 @@ REM Auto-elevates (admin) only if PORT < 1024 (e.g. port 80)
 cd /d "%~dp0"
 
 set PORT=5151
+set "FLASK_ENV=production"
 if exist .env (
     for /f "tokens=1,2 delims==" %%a in (.env) do (
         if "%%a"=="PORT" set PORT=%%b
+        if "%%a"=="FLASK_ENV" set FLASK_ENV=%%b
+    )
+)
+
+REM Use default USERPROFILE with environment-specific Azure CLI config directory.
+if /I "%FLASK_ENV%"=="production" (
+    set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddy\.azure"
+) else (
+    if /I "%FLASK_ENV%"=="development" (
+        set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddyDev\.azure"
+    ) else (
+        set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddy\.azure"
     )
 )
 

--- a/templates/admin_panel.html
+++ b/templates/admin_panel.html
@@ -1217,6 +1217,12 @@ function updateMsxStatusDisplay(state, detail) {
 // This is the single entry point: check token, try auto-acquiring if needed,
 // only show "Not Connected" if everything fails.
 async function loadMsxStatus() {
+    // Clear any stale test result alerts when refreshing status
+    const testResult = document.getElementById('msxTestResult');
+    if (testResult) testResult.innerHTML = '';
+    const testHr = document.getElementById('msxTestResultHr');
+    if (testHr) testHr.classList.add('d-none');
+
     try {
         const response = await fetch('/api/msx/status');
         const data = await response.json();
@@ -1504,6 +1510,8 @@ document.getElementById('msxTestBtn').addEventListener('click', async function()
             if (data.vpn_blocked && window.showVpnBanner) {
                 window.showVpnBanner();
             }
+            // Show sign-in section if not authenticated
+            loadMsxStatus();
         }
     } catch (err) {
         resultDiv.innerHTML = `

--- a/update.bat
+++ b/update.bat
@@ -4,9 +4,22 @@ REM Auto-elevates (admin) only if PORT in .env is below 1024 (e.g. port 80)
 cd /d "%~dp0"
 
 set PORT=5151
+set "FLASK_ENV=production"
 if exist .env (
     for /f "tokens=1,2 delims==" %%a in (.env) do (
         if "%%a"=="PORT" set PORT=%%b
+        if "%%a"=="FLASK_ENV" set FLASK_ENV=%%b
+    )
+)
+
+REM Use default USERPROFILE with environment-specific Azure CLI config directory.
+if /I "%FLASK_ENV%"=="production" (
+    set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddy\.azure"
+) else (
+    if /I "%FLASK_ENV%"=="development" (
+        set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddyDev\.azure"
+    ) else (
+        set "AZURE_CONFIG_DIR=%USERPROFILE%\SalesBuddy\.azure"
     )
 )
 


### PR DESCRIPTION

## Azure CLI Config Isolation

Isolates Azure CLI state (`~/.azure`) per environment so the default (%USERPROFILE%),  production (%USERPROFILE%/SalesBuddy), and development (%USERPROFILE%/SalesBuddyDev) PowerShell az cli .azure environment instances don't share or corrupt each other's login sessions.  This is important due to DSEs often needing to maintain connections to other development tenants through az cli than the default MSFT tenant.  Having to switch tenant contexts can be laborious, especially if the tenant GUID isn't readily available in the command history.

### Problem

All Sales Buddy instances (production and development) shared the same `%USERPROFILE%\.azure` directory. An `az login` in one environment could overwrite the other's cached credentials, and dev testing risked polluting the production token cache.

### Solution

Each environment now gets its own `.azure` directory:

- **Non-SalesBuddy Related Default**: `%USERPROFILE%\.azure`
- **Production**: `%USERPROFILE%\SalesBuddy\.azure`
- **Development**: `%USERPROFILE%\SalesBuddyDev\.azure`

The Default az cli environment is no longer involved with Sales Buddy and is isolated to allow for other development work to happen independently.  The Sales Buddy az cli environment path is now derived from `FLASK_ENV` in .env (defaults to production for any unrecognized value).

### Changes

**Environment variable propagation** (start.bat, stop.bat, update.bat)
- Read `FLASK_ENV` from .env and compute `AZURE_CONFIG_DIR` with explicit three-way branching (production / development / catch-all)

**Bootstrap and migration** (server.ps1)
- New `Initialize-IsolatedAzCliContext` function runs on every startup
- First-run bootstrap: copies existing `%USERPROFILE%\.azure` to the environment-specific path automatically (no re-authentication needed)
- Retry-on-empty: re-attempts migration if target directory exists but is empty (failed copy recovery)
- Sets `AZURE_CONFIG_DIR` and `SALESBUDDY_HOME` environment variables for the process tree

**Waitress subprocess environment inheritance** (server.ps1)
- Replaced `Start-Process` with `ProcessStartInfo` to explicitly pass environment variables to the waitress child process
- `Start-Process` doesn't inherit parent environment; `ProcessStartInfo` with explicit env dict does
- Redirects stdout/stderr to prevent waitress log noise in the parent terminal

**Explicit env passing for all `az` Popen calls** (msx_auth.py, metrics.py)
- Added `env=os.environ.copy()` to all 4 `subprocess.Popen` calls that spawn `az login` / `az login --use-device-code`
- `subprocess.run` calls inherit implicitly (verified), but `Popen` calls now do so explicitly for robustness

**Startup diagnostics** (server.ps1)
- `[OK]` (green) when config directory is set with migrated credentials
- `[WARNING]` (yellow) when no existing az CLI context found (fresh install, login required)
- `[FAILURE]` (red) with error message, file, and line number if bootstrap throws

**Admin panel UX** (admin_panel.html)
- "Test Connection" failure now triggers `loadMsxStatus()` to surface the "Sign In to Azure" button
- `loadMsxStatus()` clears stale test result alerts so "Connection Failed" doesn't persist after successful sign-in

**Gitignore** (.gitignore)
- Added Microsoft to ignore PowerShell module cache artifacts

### Files Changed (8)

| File | What |
|------|------|
| start.bat | FLASK_ENV reading, AZURE_CONFIG_DIR derivation |
| stop.bat | Same |
| update.bat | Same |
| server.ps1 | Bootstrap function, ProcessStartInfo, startup diagnostics |
| msx_auth.py | Explicit `env=` on 3 Popen calls |
| metrics.py | Explicit `env=` on 1 Popen call |
| admin_panel.html | Test connection UX fixes |
| .gitignore | Ignore Microsoft |

### Testing

- Verified migration path: deleted `.azure`, restarted, confirmed auto-copy from default
- Verified fresh install path: renamed default `.azure`, restarted, confirmed empty dir + warning
- Verified sign-in flow: used admin panel "Sign In to Azure" button, confirmed credentials land in isolated directory
- 46/46 MSX tests pass